### PR TITLE
usage of strict unmarshalling; error message fix; removed linter duplications

### DIFF
--- a/gometalinter.json
+++ b/gometalinter.json
@@ -15,8 +15,7 @@
     "vetshadow",
     "ineffassign",
     "misspell",
-    "gotypex",
-    "vetshadow"
+    "gotypex"
   ],
   "Cyclo": 10,
   "LineLength": 120

--- a/mta/mta.go
+++ b/mta/mta.go
@@ -53,7 +53,7 @@ func (mta *MTA) GetResourceByName(name string) (*Resource, error) {
 func Unmarshal(content []byte) (*MTA, error) {
 	m := &MTA{}
 	// Unmarshal MTA file
-	err := yaml.Unmarshal([]byte(content), &m)
+	err := yaml.UnmarshalStrict([]byte(content), &m)
 	if err != nil {
 		err = errors.Wrap(err, "failed to unmarshal the MTA object")
 	}

--- a/validations/semantic_uniqueness.go
+++ b/validations/semantic_uniqueness.go
@@ -35,7 +35,7 @@ func validateNameUniqueness(names map[string]string, name string,
 	// name found -> add issue
 	if ok {
 		result = appendIssue(result,
-			fmt.Sprintf("the %s %s is not unique because the %s was found with the same name",
+			fmt.Sprintf("the %s %s is not unique because a %s was found with the same name",
 				name, objectName, prevObjectName))
 	} else {
 		// name not found -> add it to the global map

--- a/validations/semantic_uniqueness_test.go
+++ b/validations/semantic_uniqueness_test.go
@@ -58,7 +58,7 @@ modules:
 `)
 		mta, _ := mta.Unmarshal(mtaContent)
 		issues := validateNamesUniqueness(mta, "")
-		Ω(issues[0].Msg).Should(Equal("the ui5app module is not unique because the module was found with the same name"))
+		Ω(issues[0].Msg).Should(Equal("the ui5app module is not unique because a module was found with the same name"))
 	})
 	It("module and provides have the same name", func() {
 		mtaContent := []byte(`
@@ -77,7 +77,7 @@ modules:
 `)
 		mta, _ := mta.Unmarshal(mtaContent)
 		issues := validateNamesUniqueness(mta, "")
-		Ω(issues[0].Msg).Should(Equal("the ui5app2 module is not unique because the provided service was found with the same name"))
+		Ω(issues[0].Msg).Should(Equal("the ui5app2 module is not unique because a provided service was found with the same name"))
 	})
 	It("resource and provides have the same name", func() {
 		mtaContent := []byte(`
@@ -103,6 +103,6 @@ resources:
 `)
 		mta, _ := mta.Unmarshal(mtaContent)
 		issues := validateNamesUniqueness(mta, "")
-		Ω(issues[0].Msg).Should(Equal("the test resource is not unique because the provided service was found with the same name"))
+		Ω(issues[0].Msg).Should(Equal("the test resource is not unique because a provided service was found with the same name"))
 	})
 })

--- a/validations/semantic_validate.go
+++ b/validations/semantic_validate.go
@@ -12,7 +12,7 @@ type checkSemantic func(mta *mta.MTA, source string) []YamlValidationIssue
 func runSemanticValidations(yamlContent []byte, source string) []YamlValidationIssue {
 	var issues []YamlValidationIssue
 	mtaStr := mta.MTA{}
-	err := yaml.Unmarshal(yamlContent, &mtaStr)
+	err := yaml.UnmarshalStrict(yamlContent, &mtaStr)
 	if err != nil {
 		issues = appendIssue(issues, "validation failed when unmarshalling the MTA file because: "+err.Error())
 		return issues

--- a/validations/semantic_validate_test.go
+++ b/validations/semantic_validate_test.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -39,6 +40,29 @@ resources:
 		Ω(issues[0].Msg).Should(
 			Equal("the ui5app2 path of the ui5app2 module does not exist"))
 		Ω(issues[1].Msg).
-			Should(Equal("the test resource is not unique because the provided service was found with the same name"))
+			Should(Equal("the test resource is not unique because a provided service was found with the same name"))
+	})
+
+	It("Sanity", func() {
+		mtaContent := []byte(`
+ID: mtahtml5
+_schema-version: '2.1'
+version: 0.0.1
+
+modules:
+ - name: ui5app
+   type: html5
+   provides:
+   - name: test
+   parameters:
+      service-plan: lite
+      service: destination
+      service: destination1
+`)
+		issues := runSemanticValidations(mtaContent, getTestPath("testproject"))
+		Ω(len(issues)).Should(Equal(1))
+		fmt.Println(issues[0].Msg)
+		Ω(issues[0].Msg).Should(
+			ContainSubstring(`line 14: key "service" already set in map`))
 	})
 })


### PR DESCRIPTION
unmarshalling of the mta.yaml changed to be a strict one; error message fix; removed linter duplications

### Checklist
- [x] Code compiles correctly
- [x] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [x] Formating and linting run locally successfully
- [x] All tests passing
- [x] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved


