### PR TITLE
Don't perform schema validations on null nodes

### DIFF
--- a/validations/schema_validate.go
+++ b/validations/schema_validate.go
@@ -285,6 +285,9 @@ func optional(checks ...YamlCheck) YamlCheck {
 
 func typeIsNotMapArray() YamlCheck {
 	return func(yNode, yParentNode *yaml.Node, path []string) YamlValidationIssues {
+		if yNode == nil {
+			return []YamlValidationIssue{}
+		}
 
 		if yNode.Kind == yaml.SequenceNode || yNode.Kind == yaml.MappingNode {
 			return []YamlValidationIssue{
@@ -355,6 +358,10 @@ func matchesRegExp(pattern string) YamlCheck {
 	regExp, _ := regexp.Compile(pattern)
 
 	return func(yNode, yParentNode *yaml.Node, path []string) YamlValidationIssues {
+		if yNode == nil {
+			return []YamlValidationIssue{}
+		}
+
 		strValue := yNode.Value
 
 		if !regExp.MatchString(strValue) {
@@ -387,6 +394,10 @@ func matchesEnumValues(enumValues []string) YamlCheck {
 	}
 
 	return func(yNode, yParentNode *yaml.Node, path []string) YamlValidationIssues {
+		if yNode == nil {
+			return []YamlValidationIssue{}
+		}
+
 		value := yNode.Value
 		found := false
 		for _, enumValue := range enumValues {

--- a/validations/schema_validate_test.go
+++ b/validations/schema_validate_test.go
@@ -44,6 +44,10 @@ firstName: Donald
 lastName: duck
 `, property("firstName", typeIsNotMapArray())),
 
+		Entry("Type is String when property doesn't exist", `
+lastName: duck
+`, property("firstName", typeIsNotMapArray())),
+
 		Entry("Type Is Bool", `
 name: bisli
 registered: false

--- a/validations/schema_validations_builder_test.go
+++ b/validations/schema_validations_builder_test.go
@@ -97,11 +97,27 @@ mapping:
 `, `
 firstName: Donald
 lastName: duck`),
+		Entry("required field inside mapping, when parent is null", `
+type: map
+mapping:
+  inner:
+    type: map
+    mapping:
+      firstName:  {required: true}
+`, `{}`),
 		Entry("Enum value", `
 enum:
   - duck
   - dog
 `, `duck`),
+		Entry("null enum value", `
+type: map
+mapping:
+  animal:
+   enum:
+    - duck
+    - dog
+`, `{}`),
 		Entry("sequence", `
 type: seq
 sequence:
@@ -169,6 +185,13 @@ mapping:
 firstName: Donald
 lastName: duck
 `),
+		Entry("Pattern when value is null", `
+type: map
+mapping:
+   firstName:  {pattern: '/^[a-zA-Z]+$/'}
+`, `
+lastName: duck
+`),
 		Entry("optional", `
 type: map
 mapping:
@@ -202,6 +225,26 @@ mapping:
 firstName: Donald
 lastName: duck
 `, `missing the "age" required property in the root .yaml node`, 2),
+
+		Entry("required mapping field", `
+type: map
+mapping:
+  inner:
+    type: map
+    required: true
+    mapping:
+      firstName: {type: string}
+`, `{}`, `missing the "inner" required property in the root .yaml node`, 1),
+
+		Entry("required mapping field with inner required field", `
+type: map
+mapping:
+  inner:
+    type: map
+    required: true
+    mapping:
+      firstName: {required: true}
+`, `{}`, `missing the "inner" required property in the root .yaml node`, 1),
 
 		Entry("Enum", `
 type: str

--- a/validations/test_utils_test.go
+++ b/validations/test_utils_test.go
@@ -3,11 +3,13 @@
 package validate
 
 import (
+	"fmt"
+
 	. "github.com/onsi/gomega"
 )
 
 func assertNoValidationErrors(errors []YamlValidationIssue) {
-	Ω(len(errors)).Should(Equal(0), "Validation issues detected: %v")
+	Ω(len(errors)).Should(Equal(0), fmt.Sprintf("Validation issues detected: %v", errors))
 }
 
 func expectSingleValidationError(actual []YamlValidationIssue, expectedMsg string, expectedLine int) {


### PR DESCRIPTION
If the node is null, and it isn't required, don't perform any validations on it (since the default for "required" is false).
Support required map-type properties.
Also protect against panic by checking explicitly for nil.

### Checklist
- [X] Code compiles correctly
- [X] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
