### PR TITLE
Remove validation on mta extension file name

### DIFF
--- a/validations/ext_validate.go
+++ b/validations/ext_validate.go
@@ -2,7 +2,6 @@ package validate
 
 import (
 	"gopkg.in/yaml.v3"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -11,11 +10,6 @@ import (
 )
 
 const (
-	filenameValidation = "filename"
-
-	mtaextExtension = ".mtaext"
-
-	badExtensionErrorMsg     = `the MTA extension descriptor file name must have the "mtaext" file extension`
 	couldNotValidateErrorMsg = `could not validate the "%s" file`
 	validationErrorsMsg      = "the \"%s\" file is not valid:\n%s"
 )
@@ -52,39 +46,20 @@ func Mtaext(projectPath, extPath string,
 	return "", nil
 }
 
-func validateExtFileName(name string, strict bool) (errIssues YamlValidationIssues, warnIssues YamlValidationIssues) {
-	var issues YamlValidationIssues
-
-	if filepath.Ext(name) != mtaextExtension {
-		issues = append(issues, YamlValidationIssue{Msg: badExtensionErrorMsg, Line: 0})
-	}
-
-	if strict {
-		return issues, nil
-	}
-	return nil, issues
-}
-
 // validateExt validates the MTA extension descriptor
 func validateExt(yamlContent []byte, projectPath string, extFileName string,
 	validateSchema, validateSemantic, strict bool, exclude string) (errIssues YamlValidationIssues, warnIssues YamlValidationIssues) {
-
-	// This is a special case semantic validation, on the file name and not its content
-	if validateSemantic && !strings.Contains(exclude, filenameValidation) {
-		errIssues, warnIssues = validateExtFileName(extFileName, strict)
-	}
-
 	mtaExt, err := mta.UnmarshalExt(yamlContent)
 
 	if strict && err != nil {
-		errIssues = append(errIssues, convertError(err)...)
+		errIssues = convertError(err)
 	} else if err != nil {
-		warnIssues = append(warnIssues, convertError(err)...)
+		warnIssues = convertError(err)
 	}
 
 	extNode, err := getContentNode(yamlContent)
 	if err != nil {
-		errIssues = convertError(err)
+		errIssues = append(errIssues, convertError(err)...)
 	}
 
 	if validateSchema {

--- a/validations/ext_validate_test.go
+++ b/validations/ext_validate_test.go
@@ -104,7 +104,7 @@ desc: MTA DESCRIPTOR SCHEMA
 
 	})
 
-	It("bad file extension", func() {
+	It("file extension which is not mtaext does not cause an error", func() {
 		err, warn := validateExt([]byte(`
 ID: mymtaext
 extends: somemta
@@ -112,33 +112,8 @@ _schema-version: '3.1'
 `), getTestPath("mtahtml5"), "ext.yaml",
 			false, true, true, "")
 		Ω(warn).Should(BeNil())
-		Ω(err).Should(ConsistOf(YamlValidationIssue{badExtensionErrorMsg, 0}))
+		Ω(err).Should(BeNil())
 	})
-
-	DescribeTable("validateExtFileName", func(filename string, expectedSuccess bool) {
-		if expectedSuccess {
-			errIssues, warnIssues := validateExtFileName(filename, true)
-			Ω(errIssues).Should(BeNil())
-			Ω(warnIssues).Should(BeNil())
-			errIssues, warnIssues = validateExtFileName(filename, false)
-			Ω(errIssues).Should(BeNil())
-			Ω(warnIssues).Should(BeNil())
-		} else {
-			errIssues, warnIssues := validateExtFileName(filename, true)
-			Ω(errIssues).ShouldNot(BeNil())
-			Ω(len(errIssues)).Should(Equal(1))
-			Ω(warnIssues).Should(BeNil())
-			errIssues, warnIssues = validateExtFileName(filename, false)
-			Ω(errIssues).Should(BeNil())
-			Ω(warnIssues).ShouldNot(BeNil())
-			Ω(len(warnIssues)).Should(Equal(1))
-		}
-	},
-		Entry("file name is mtaext", "mtaext", false),
-		Entry("file name has mtaext extension", "a.mtaext", true),
-		Entry("file name has yaml extension", "ext.yaml", false),
-		Entry("file name is mtaext and has yaml extension", "mtaext.yaml", false),
-	)
 
 	It("Unallowed fields in extension file return errors", func() {
 		err, warn := validateExt([]byte(`


### PR DESCRIPTION
Other tools (e.g. mta deployer) don't check the file name, so there is no need to limit it.

### Checklist
- [X] Code compiles correctly
- [X] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved


