### PR TITLE
Don't return the same mtaext unmarshal error twice from validation

### DIFF
--- a/validations/ext_validate.go
+++ b/validations/ext_validate.go
@@ -49,17 +49,18 @@ func Mtaext(projectPath, extPath string,
 // validateExt validates the MTA extension descriptor
 func validateExt(yamlContent []byte, projectPath string, extFileName string,
 	validateSchema, validateSemantic, strict bool, exclude string) (errIssues YamlValidationIssues, warnIssues YamlValidationIssues) {
-	mtaExt, err := mta.UnmarshalExt(yamlContent)
+	extNode, err := getContentNode(yamlContent)
+	if err != nil {
+		errIssues = convertError(err)
+	}
 
+	// Errors from this unmarshal include those from getContentNode and have more validations, so they should override
+	// the previous errors
+	mtaExt, err := mta.UnmarshalExt(yamlContent)
 	if strict && err != nil {
 		errIssues = convertError(err)
 	} else if err != nil {
 		warnIssues = convertError(err)
-	}
-
-	extNode, err := getContentNode(yamlContent)
-	if err != nil {
-		errIssues = append(errIssues, convertError(err)...)
 	}
 
 	if validateSchema {

--- a/validations/ext_validate_test.go
+++ b/validations/ext_validate_test.go
@@ -71,6 +71,23 @@ var _ = Describe("MTAEXT validation tests", func() {
 			Ω(err[0].Msg).Should(ContainSubstring("cannot unmarshal"))
 		})
 
+		It("Only returns unmarshaling error once", func() {
+			err, warn := validateExt([]byte(`- bad Yaml
+a b`), getTestPath("mtahtml5"), "my.mtaext",
+				true, false, true, "")
+			Ω(warn).Should(BeNil())
+			Ω(err).ShouldNot(BeNil())
+
+			// Check we don't get the same error twice
+			errorsMap := make(map[string]interface{})
+			for _, value := range err {
+				if _, ok := errorsMap[value.Msg]; ok {
+					Ω(ok).Should(BeFalse(), fmt.Sprintf("Got the same message twice: %s", value.Msg))
+				}
+				errorsMap[value.Msg] = nil
+			}
+		})
+
 		It("Empty mta content", func() {
 			err, warn := validateExt([]byte(""), "a.mtaext", getTestPath("mtahtml5"),
 				true, false, true, "")


### PR DESCRIPTION
### Checklist
- [X] Code compiles correctly
- [X] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved


