### PR TITLE
fix: support windows paths in mta resolve command

### DIFF
--- a/cmd/resolver.go
+++ b/cmd/resolver.go
@@ -7,19 +7,19 @@ import (
 )
 
 var resolvePath string
-var workspaceDir string
+var resolveWorkspaceDir string
 var resolveModule string
 var resolveEnvFileName string
 
 func init() {
 	resolveMtaCmd.Flags().StringVarP(&resolvePath, "path", "p", "",
-		"the path to the yaml file")
-	resolveMtaCmd.Flags().StringVarP(&workspaceDir, "workspace", "w", "",
-		"the path to workspace-folder")
+		"the path to the mta.yaml file")
+	resolveMtaCmd.Flags().StringVarP(&resolveWorkspaceDir, "workspace", "w", "",
+		"the path to the project folder; the default path is the folder of the mta.yaml file")
 	resolveMtaCmd.Flags().StringVarP(&resolveModule, "module", "m", "",
-		"module-name")
+		"the module name")
 	resolveMtaCmd.Flags().StringVarP(&resolveEnvFileName, "envFile", "e", "",
-		"the environment file name. The default file name is .env")
+		"the environment file path, relative to the module folder; the default file path is \".env\"")
 
 }
 
@@ -27,13 +27,12 @@ func init() {
 var resolveMtaCmd = &cobra.Command{
 	Use:   "resolve",
 	Short: "Resolve variables and placeholders in an MTA file",
-	Long: `MTA file typically contains variables in the form ~{var-name} and placeholders in the form ${placeholder}, 
-resolve command print to stdout the MTA fil contents with as much as possible variables and placeholders replaced 
-with concrete values, based on environment variables provided and environment files in the modules' folders`,
+	Long: `The MTA file typically contains variables in the form ~{var-name} and placeholders in the form ${placeholder}.
+The resolve command prints the module's properties from the MTA file to stdout, with variables and placeholders replaced with concrete values, based on environment variables and an environment file.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logs.Logger.Info("Resolve MTA")
-		err := resolver.Resolve(workspaceDir, resolveModule, resolvePath, resolveEnvFileName)
+		err := resolver.Resolve(resolveWorkspaceDir, resolveModule, resolvePath, resolveEnvFileName)
 		if err != nil {
 			logs.Logger.Error(err)
 		}

--- a/internal/resolver/testdata/test-project/srv/.env_with_vcap
+++ b/internal/resolver/testdata/test-project/srv/.env_with_vcap
@@ -1,0 +1,5 @@
+health-check-type=https
+eb-msahaa/heap2=50m
+ed-aaa/heap=150m
+env_var1=vvv
+VCAP_SERVICES={"aaa": [{"name": "ed-aaa-service","instance_name": "aaa","label": "aaa","tags": ["mta-resource-name:ed-aaa"],"plan": "aaa"},{"name": "ed-bbb-service","instance_name": "bbb","label": "bbb","tags": ["mta-resource-name:ed-bbb"],"plan": "bbb"}]}


### PR DESCRIPTION
+ Support absolute path to `.env` file
+ Output missing parameter names as a warning through the logger
+ Change some descriptions in the command to make them clearer
+ Add a test where vcap_services is read from the .env file

### Checklist
- [X] Code compiles correctly
- [X] Relevant tests were added (unit / contract / integration)
- [X] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
