### PR TITLE
[Fix] Resolve - parameter from env has higher priority

### DIFF
--- a/internal/resolver/mtaresolver.go
+++ b/internal/resolver/mtaresolver.go
@@ -416,22 +416,30 @@ func (m *MTAResolver) resolvePlaceholdersString(sourceModule *mta.Module, source
 
 func (m *MTAResolver) getParameterFromSource(source *mtaSource, paramName string) string {
 	if source != nil {
+		// See if the value was configured externally first (in VCAP_SERVICES, env var etc)
+		// The source can be a module or a resource
+		module, ok := m.context.modules[source.Name]
+		if ok {
+			paramValStr, ok := module[paramName]
+			if ok {
+				return paramValStr
+			}
+		}
+
+		resource, ok := m.context.resources[source.Name]
+		if ok {
+			paramValStr, ok := resource[paramName]
+			if ok {
+				return paramValStr
+			}
+		}
+
+		// If it was not defined externally, try to get it from the source parameters
 		paramVal := source.Parameters[paramName]
 		if paramVal != nil {
 			return paramVal.(string)
 		}
 
-		//defaults to context's module params:
-		paramValStr, ok := m.context.modules[source.Name][paramName]
-		if ok {
-			return paramValStr
-		}
-
-		//defaults to context's resource params:
-		paramValStr, ok = m.context.resources[source.Name][paramName]
-		if ok {
-			return paramValStr
-		}
 	}
 	return ""
 }

--- a/internal/resolver/mtaresolver_test.go
+++ b/internal/resolver/mtaresolver_test.go
@@ -96,6 +96,7 @@ var _ = Describe("Resolve", func() {
 		`JBP_CONFIG_companyJVM=[ memory_calculator: { memory_sizes: { heap: 1000m, stack: 1m, metaspace: 150m } } ]`,
 		`JBP_CONFIG_companyJVM1=[ memory_calculator: { memory_sizes: { heap: 1000m, stack: 1m, metaspace: 150m } } ]`,
 		`JBP_CONFIG_RESOURCE_CONFIGURATION=[tomcat/webapps/ROOT/META-INF/context.xml: {"service_name_for_DefaultDB" : "ed-aaa-service"}]`,
+		`bbb_service=ed-bbb-service`,
 	}
 
 	It("Sanity", func() {
@@ -136,6 +137,7 @@ var _ = Describe("Resolve", func() {
 			`JBP_CONFIG_companyJVM=[ memory_calculator: { memory_sizes: { heap: 1000m, stack: 1m, metaspace: 150m } } ]`,
 			`JBP_CONFIG_companyJVM1=[ memory_calculator: { memory_sizes: { heap: 1000m, stack: 1m, metaspace: 150m } } ]`,
 			`JBP_CONFIG_RESOURCE_CONFIGURATION=[tomcat/webapps/ROOT/META-INF/context.xml: {"service_name_for_DefaultDB" : "ed-aaa-service"}]`,
+			`bbb_service=ed-bbb-service`,
 		}
 		callResolveAndValidateOutput(wd, "eb-java", yamlPath, expectedResolve, ".env2")
 	})
@@ -149,7 +151,8 @@ var _ = Describe("Resolve", func() {
 	It("Sanity - working dir not provided, no VCAP services", func() {
 		yamlPath := getTestPath("test-project", "mta.yaml")
 		envGetter = mockEnvGetterExt
-		expected[len(expected)-1] = strings.Replace(expected[len(expected)-1], "ed-aaa-service", "${service-name}", -1)
+		expected[len(expected)-2] = strings.Replace(expected[len(expected)-2], "ed-aaa-service", "${service-name}", -1)
+		expected[len(expected)-1] = strings.Replace(expected[len(expected)-1], "ed-bbb-service", "ed-bbb-param", -1)
 		callResolveAndValidateOutput("", "eb-java", yamlPath, expected, "")
 	})
 	It("empty module name", func() {
@@ -235,7 +238,12 @@ var _ = Describe("convertToString", func() {
 
 var _ = Describe("getParameter", func() {
 	It("parameter found in source parameters", func() {
-		resolver := MTAResolver{}
+		resolver := MTAResolver{
+			context: &ResolveContext{
+				modules:   map[string]map[string]string{},
+				resources: map[string]map[string]string{},
+			},
+		}
 		source := mtaSource{
 			Parameters: map[string]interface{}{
 				"param1": "value1",

--- a/internal/resolver/testdata/test-project/mta.yaml
+++ b/internal/resolver/testdata/test-project/mta.yaml
@@ -11,6 +11,8 @@ modules:
     properties:
       JBP_CONFIG_RESOURCE_CONFIGURATION: '[tomcat/webapps/ROOT/META-INF/context.xml: {"service_name_for_DefaultDB" : "~{aaa-container-name}"}]'
   - name: ed-bbb
+    properties:
+      bbb_service: ~{the-service-name}
   - name: ed-con
   - name: ed-dest
   - name: ed-sb-bbb
@@ -365,7 +367,7 @@ resources:
 - name: ed-bbb
   type: com.company.ms.bbb
   parameters:
-    service-name: ed-bbb
+    service-name: ed-bbb-param
     config:
       xcompanypname: 'ed-${space}'
       tenant-mode: dedicated
@@ -434,6 +436,8 @@ resources:
         - bbb.user
       oauth2-configuration:
         token-validity: 31536000
+  properties:
+    the-service-name: ${service-name}
 
 - name: ed-sb-bbb
   type: org.cloudfoundry.managed-service


### PR DESCRIPTION
## Description

If the parameter is defined both in vcap_services (bound service name)
and in the mta.yaml under the resource parameters, the value from
vcap_services should be used.

### Checklist
- [V] Code compiles correctly
- [V] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [V] Formatting and linting run locally successfully
- [V] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
