### PR TITLE
chore: add json tags to mta_ext schema

### DIFF
--- a/mta/mta_ext_schema.go
+++ b/mta/mta_ext_schema.go
@@ -3,23 +3,23 @@ package mta
 // EXT mta extension schema
 type EXT struct {
 	// indicates MTA schema version, using semver.
-	SchemaVersion *string `yaml:"_schema-version"`
+	SchemaVersion *string `yaml:"_schema-version" json:"_schema-version"`
 	// A globally unique ID of this MTA extension. Unlimited string of unicode characters.
-	ID string `yaml:"ID"`
+	ID string `yaml:"ID" json:"ID"`
 	// A non-translatable description of this MTA extension. This is not a text for application users
-	Description string `yaml:"description,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	//  a globally unique ID of the MTA or the MTA extension which shall be extended by this descriptor
-	Extends string `yaml:"extends"`
+	Extends string `yaml:"extends" json:"extends"`
 	// Application version, using semantic versioning standard
-	Version string `yaml:"version,omitempty"`
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 	// The provider of this extension descriptor
-	Provider string `yaml:"provider,omitempty"`
+	Provider string `yaml:"provider,omitempty" json:"provider,omitempty"`
 	// list of modules
-	Modules []*ModuleExt `yaml:"modules,omitempty"`
+	Modules []*ModuleExt `yaml:"modules,omitempty" json:"modules,omitempty"`
 	// Resource declarations. Resources can be anything required to run the application which is not provided by the application itself
-	Resources []*ResourceExt `yaml:"resources,omitempty"`
+	Resources []*ResourceExt `yaml:"resources,omitempty" json:"resources,omitempty"`
 	// Parameters can be used to steer the behavior of tools which interpret this descriptor
-	Parameters map[string]interface{} `yaml:"parameters,omitempty"`
+	Parameters map[string]interface{} `yaml:"parameters,omitempty" json:"parameters,omitempty"`
 }
 
 // ModuleExt - modules section in MTA extension
@@ -27,17 +27,17 @@ type ModuleExt struct {
 	// An MTA internal module name. Names need to be unique within the MTA scope
 	Name string
 	// Provided property values can be accessed by "~{<name-of-provides-section>/<provided-property-name>}". Such expressions can be part of an arbitrary string
-	Properties map[string]interface{} `yaml:"properties,omitempty"`
+	Properties map[string]interface{} `yaml:"properties,omitempty" json:"properties,omitempty"`
 	// THE 'includes' ELEMENT IS ONLY RELEVANT FOR DEVELOPMENT DESCRIPTORS (PRIO TO BUILD), NOT FOR DEPLOYMENT DESCRIPTORS!
-	Includes []Includes `yaml:"includes,omitempty"`
+	Includes []Includes `yaml:"includes,omitempty" json:"includes,omitempty"`
 	// list of names either matching a resource name or a name provided by another module within the same MTA
-	Requires []Requires `yaml:"requires,omitempty"`
+	Requires []Requires `yaml:"requires,omitempty" json:"requires,omitempty"`
 	// List of provided names (MTA internal)to which properties (= configuration data) can be attached
-	Provides []Provides `yaml:"provides,omitempty"`
+	Provides []Provides `yaml:"provides,omitempty" json:"provides,omitempty"`
 	// Parameters can be used to steer the behavior of tools which interpret this descriptor. Parameters are not made available to the module at runtime
-	Parameters map[string]interface{} `yaml:"parameters,omitempty"`
+	Parameters map[string]interface{} `yaml:"parameters,omitempty" json:"parameters,omitempty"`
 	// Build-parameters are specifically steering the behavior of build tools.
-	BuildParams map[string]interface{} `yaml:"build-parameters,omitempty"`
+	BuildParams map[string]interface{} `yaml:"build-parameters,omitempty" json:"build-parameters,omitempty"`
 	// Defined and executed at specific phases of module deployment.
 	Hooks []Hook `yaml:"hooks,omitempty" json:"hooks,omitempty"`
 }
@@ -46,11 +46,11 @@ type ModuleExt struct {
 type ResourceExt struct {
 	Name string
 	// A type of a resource. This type is interpreted by and must be known to the deployer. Resources can be untyped
-	Parameters map[string]interface{} `yaml:"parameters,omitempty"`
+	Parameters map[string]interface{} `yaml:"parameters,omitempty" json:"parameters,omitempty"`
 	// property names and values make up the configuration data which is to be provided to requiring modules at runtime
-	Properties map[string]interface{} `yaml:"properties,omitempty"`
+	Properties map[string]interface{} `yaml:"properties,omitempty" json:"properties,omitempty"`
 	// If a resource is declared to be active, it is allocated and bound according to declared requirements
-	Active *bool `yaml:"active,omitempty"`
+	Active *bool `yaml:"active,omitempty" json:"active,omitempty"`
 	// list of names either matching a resource name or a name provided by another module within the same MTA
 	Requires []Requires `yaml:"requires,omitempty" json:"requires,omitempty"`
 }


### PR DESCRIPTION
## Description

This PR adds `json` tags to the MTA Ext schema, which are already there for the MTA schema.
This enables users to also use the [kubernetes yaml parser](https://pkg.go.dev/sigs.k8s.io/yaml), which is working on json tags.

### Checklist
- [x] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [x] Formating and linting run locally successfully
- [x] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved


